### PR TITLE
prevent pausePlayButton in iOS

### DIFF
--- a/jquery.background-video.js
+++ b/jquery.background-video.js
@@ -166,7 +166,7 @@
 
 
 			// Play / pause button
-			if( el_settings.showPausePlay ) {
+			if( el_settings.showPausePlay && !iOS ) {
 				// Append pauseplay element created earlier
 				$container.append($pauseplay);
 				// Position element


### PR DESCRIPTION
The script deleted the video-tag in iOS. So the per default shown
pausePlay-Button is in iOS all the time disorienting.
The && !iOS will return false if the system is iOS and no time the
button will be shown in this system.