### PR TITLE
add iOS 10+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Or just download the zip
 
 ```html
 <div class="element-with-video-bg jquery-background-video-wrapper">
-	<video class="my-background-video jquery-background-video" loop autoplay muted poster="path/to/your/poster.jpg">
+	<video class="my-background-video jquery-background-video" loop autoplay muted playsinline poster="path/to/your/poster.jpg">
 		<source src="path/to/video.mp4" type="video/mp4">
 		<source src="path/to/video.webm" type="video/webm">
 		<source src="path/to/video.ogv" type="video/ogg">
@@ -57,6 +57,8 @@ If you're using the fade-in option you should also set the poster image as a `ba
 }
 ```
 It's important to use `background-image` instead of the shorthand `background` because the plugin CSS sets `background-position`, `background-repeat` and `background-size`, which would be overwritten by the shorthand `background`.
+
+iOS Support: Automatic playing of videos is supported as of iOS 10+, but requires the `playsinline` attribute on the `<video>` tag.
 
 ### 4. Call the plugin on the video element
 In your main JavaScript file

--- a/jquery.background-video.js
+++ b/jquery.background-video.js
@@ -39,7 +39,19 @@
 	$.fn.bgVideo = function( options ) {
 
 		// @bool iOS
-		var iOS = /iPad|iPhone|iPod/.test(navigator.platform) || /iPad|iPhone|iPod/.test(navigator.userAgent);
+		function iOSversion() {
+			if (/iP(hone|od|ad)/.test(navigator.platform)) {
+				var v = (navigator.appVersion).match(/OS (\d+)_(\d+)_?(\d+)?/);
+				return [parseInt(v[1], 10), parseInt(v[2], 10), parseInt(v[3] || 0, 10)];
+			}
+		}
+
+		var iOSVersion = iOSversion();
+		var old_iOS = false;
+
+		if (iOSVersion && (iOSVersion[0] < 10)){
+			old_iOS = true;
+		}
 
 		// Settings
 		var settings = $.extend({}, $.fn.bgVideo.defaults, options );
@@ -135,7 +147,7 @@
 
 
 			// Remove on iOS
-			if( iOS ) {
+			if( old_iOS ) {
 				// Unset sources to prevent them from continuing to download
 				$video.attr('src', '');
 				$video.find('source').attr('src', '');
@@ -166,7 +178,7 @@
 
 
 			// Play / pause button
-			if( el_settings.showPausePlay && !iOS ) {
+			if( el_settings.showPausePlay && !old_iOS ) {
 				// Append pauseplay element created earlier
 				$container.append($pauseplay);
 				// Position element


### PR DESCRIPTION
iOS 10+ supports automatic playing of video for `<video>` tags, as long as the video tag includes the `playsinline` attribute ([among other things](https://webkit.org/blog/6784/new-video-policies-for-ios/)). This PR adds a filter to check iOS versions. The plugin still deletes the video instance if it's on an unsupported version of iOS, but will keep it if it is supported. Tested with iPhones 6-10 on BrowserStack. 